### PR TITLE
Update hexchat snapcraft.yml

### DIFF
--- a/hexchat/snapcraft.yaml
+++ b/hexchat/snapcraft.yaml
@@ -1,6 +1,6 @@
 name: hexchat
-version: "2.12.1"
-summary: IRC client for X based on X-Chat 2
+version: 2.12.1
+summary: HexChat IRC Client
 description: |
   HexChat is a graphical IRC client with a GTK+ GUI. Features include Python
   and Perl scripting support, a plugin API, multiple server/channel windows,
@@ -11,27 +11,26 @@ confinement: strict
 apps:
   hexchat:
     command: desktop-launch $SNAP/bin/hexchat
-    plugs: [network, network-bind, x11, unity7]
+    plugs:
+      - unity7
+      - gsettings
+      - pulseaudio
+      - network
+      - network-bind
+      - home
 parts:
   hexchat:
-    plugin: autotools 
-    source: https://github.com/hikiko/hexchat.git
     build-packages:
-      - autoconf-archive
-      - liblua5.3-dev
-      - imagemagick
       - intltool
-      - libcanberra-dev
-      - libdbus-glib-1-dev
-      - libglib2.0-dev
-      - libgtk2.0-dev
-      - libnotify-dev
-      - libpci-dev
-      - libperl-dev
+      - libtool
       - libproxy-dev
       - libssl-dev
-      - libtool
       - python-dev
-    snap:
-      - -lib/pkgconfig
-    after: [desktop/gtk2]
+      - libperl-dev
+      - liblua5.3-dev
+      after:
+        - desktop/gtk2
+      plugin: autotools
+      source: https://dl.hexchat.net/hexchat/hexchat-2.12.1.tar.xz
+      snap:
+        - -lib/pkgconfig


### PR DESCRIPTION
Update for smaller set of dependencies and tidy-up inlined options.
Also change from building hexchat's HEAD off github to using the published/versioned tar-package.
